### PR TITLE
Bump required scikit-image version to 0.25.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,11 @@ MAINTAINER_EMAIL = "leihu@andrew.cmu.edu"
 DOWNLOAD_URL = 'https://github.com/thomasvrussell/sfft'
 
 LICENSE = 'MIT License'
-VERSION = '1.6.4.dev3'
+VERSION = '1.6.4.dev5'
 
 install_reqs = ['scipy>=1.5.2',
                 'astropy>=3.2.3',
-                'scikit-image>=0.16.2,<=0.18.3',
+                'scikit-image>=0.25.2',
                 'fastremap>=1.7.0',
                 'sep>=1.0.3',
                 'numba>=0.53.1',

--- a/sfft/utils/SExSkySubtract.py
+++ b/sfft/utils/SExSkySubtract.py
@@ -80,10 +80,12 @@ class SEx_SkySubtract:
 
         """
 
+        procid = multiprocessing.current_process().pid
+
         # * Generate SExtractor OBJECT-MASK
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            _logger.debug( f"Process {multiprocessing.current_process().pid} running PY_SEx.PS on {FITS_obj}..." )
+            _logger.debug( f"Process {procid} running PY_SEx.PS on {FITS_obj}..." )
             # NOTE: GAIN, SATURATE, ANALYSIS_THRESH, DEBLEND_MINCONT, BACKPHOTO_TYPE do not affect the detection mask.
             DETECT_MASK = PY_SEx.PS(FITS_obj=FITS_obj, SExParam=['X_IMAGE', 'Y_IMAGE'], GAIN_KEY='PHGAIN', SATUR_KEY=SATUR_KEY,
                                     BACK_TYPE='AUTO', BACK_SIZE=BACK_SIZE, BACK_FILTERSIZE=BACK_FILTERSIZE,
@@ -92,7 +94,7 @@ class SEx_SkySubtract:
                                     CHECKIMAGE_TYPE='OBJECTS', MDIR=MDIR, VERBOSE_LEVEL=VERBOSE_LEVEL,
                                     logger=_logger
                                     )[1][0].astype(bool)
-            _logger.debug( f"...process {multiprocessing.current_process().pid} done running PY_SEx.PS on {FITS_obj}..." )
+            _logger.debug( f"...process {procid} done running PY_SEx.PS on {FITS_obj}..." )
 
         # * Extract SExtractor SKY-MAP from the Unmasked Image
         _logger.debug( f"Running fits.getdata({FITS_obj}, ext=0)..." )
@@ -103,6 +105,7 @@ class SEx_SkySubtract:
         if not _PixA.flags['C_CONTIGUOUS']: _PixA = np.ascontiguousarray(_PixA)
 
         # NOTE: here we use faster sep package instead of SExtractor.
+        _logger.debug( f"Process {procid} running sep.Background" )
         sepbkg = sep.Background(_PixA, bw=BACK_SIZE, bh=BACK_SIZE, fw=BACK_FILTERSIZE, fh=BACK_FILTERSIZE)
         PixA_sky, PixA_skyrms = sepbkg.back(), sepbkg.rms()
         PixA_skysub = PixA_obj - PixA_sky
@@ -114,6 +117,7 @@ class SEx_SkySubtract:
         SKYDIP = Q1 - 1.5*IQR    # outlier rejected dip
         SKYPEAK = Q3 + 1.5*IQR   # outlier rejected peak
 
+        _logger.debug( f"Process {procid} sticking SKYRMS in {FITS_obj}" )
         with fits.open(FITS_obj) as hdl:
             FITS_obj_hdr = hdl[0].header
             FITS_obj_hdr['SKYRMS'] = ( np.median( PixA_skyrms ), 'MeLOn: Median of sky RMS' )
@@ -125,21 +129,27 @@ class SEx_SkySubtract:
             if SATUR_KEY in hdr:
                 ESATUR = float(hdr[SATUR_KEY]) - SKYPEAK    # use a conservative value
                 hdr[ESATUR_KEY] = (ESATUR, 'MeLOn: Effective SATURATE after SEx-SKY-SUB')
+            _logger.debug( f"Process {procid} writing fits file {FITS_skysub}..." )
             fits.writeto( FITS_skysub, PixA_skysub.T, hdr, overwrite=True )
+            _logger.debug( f"...process {procid} done writing fits file {FITS_skysub}." )
 
         if FITS_sky is not None:
             hdr = FITS_obj_hdr.copy()
             hdr['SKYDIP'] = (SKYDIP, 'MeLOn: IQR-MINIMUM of SEx-SKY-MAP')
             hdr['SKYPEAK'] = (SKYPEAK, 'MeLOn: IQR-MAXIMUM of SEx-SKY-MAP')
+            _logger.debug( f"Process {procid} writing fits file {FITS_sky}" )
             fits.writeto(FITS_sky, PixA_sky.T, hdr, overwrite=True)
 
         if FITS_skyrms is not None:
             hdr = FITS_obj_hdr.copy()
             hdr['SKYDIP'] = (SKYDIP, 'MeLOn: IQR-MINIMUM of SEx-SKY-MAP')
             hdr['SKYPEAK'] = (SKYPEAK, 'MeLOn: IQR-MAXIMUM of SEx-SKY-MAP')
+            _logger.debug( f"Process {procid} writing fits file {FITS_skyrms}" )
             fits.writeto(FITS_skyrms, PixA_skyrms.T, hdr, overwrite=True)
 
         if FITS_detmask is not None:
+            _logger.debug( f"Process {procid} writing fits file {FITS_detmask}" )
             fits.writeto( FITS_detmask, DETECT_MASK.T.astype( np.uint8 ), overwrite=True )
 
+        _logger.debug( f"Process {procid} returning" )
         return SKYDIP, SKYPEAK, PixA_skysub, PixA_sky, PixA_skyrms


### PR DESCRIPTION
Previously, was limited to <=0.18.3.  That had no wheel for python 3.11, so was slow to install, but more seriously, didn't work with the version of numpy we're using.

Lei says that there's something that got worse after 0.18.3 (I forget what), but that it's not something that affects what we're doing here.