### PR TITLE
Replace deprecated pkg_resources with packaging

### DIFF
--- a/sfft/utils/HoughDetection.py
+++ b/sfft/utils/HoughDetection.py
@@ -3,7 +3,7 @@ import skimage
 import warnings
 import numpy as np
 from skimage import feature
-from pkg_resources import parse_version
+from packaging import version
 from skimage.transform import hough_line, hough_line_peaks
 # version: Feb 4, 2023
 
@@ -108,18 +108,18 @@ class Hough_Detection:
         """
         
         # * check version
-        skimage_version = parse_version(skimage.__version__)
-        if skimage_version < parse_version('0.16.1'):
+        skimage_version = version.parse(skimage.__version__)
+        if skimage_version < version.parse('0.16.1'):
             if VERBOSE_LEVEL in [0, 1, 2]:
                 _warn_message = 'current scikit-image [%s] is too old and not tested!' %skimage_version
                 warnings.warn('MeLOn WARNING: %s' %_warn_message)
         
-        if parse_version('0.16.1') <= skimage_version <= parse_version('0.18.3'):
+        if version.parse('0.16.1') <= skimage_version <= version.parse('0.18.3'):
             if VERBOSE_LEVEL in [2]:
                 _message = 'current scikit-image [%s] uses classic implementation of hough transform' %skimage_version
                 print('MeLOn CheckPoint: %s' %_message)
         
-        if skimage_version >= parse_version('0.19.0'):
+        if skimage_version >= version.parse('0.19.0'):
             if VERBOSE_LEVEL in [2]:
                 _message = 'current scikit-image [%s] uses updated implementation of hough transform' %skimage_version
                 print('MeLOn CheckPoint: %s' %_message)

--- a/sfft/utils/HoughMorphClassifier.py
+++ b/sfft/utils/HoughMorphClassifier.py
@@ -1,7 +1,7 @@
 import skimage
 import warnings
 import numpy as np
-from pkg_resources import parse_version
+from packaging import version
 from sfft.utils.pyAstroMatic.PYSEx import PY_SEx
 from sfft.utils.HoughDetection import Hough_Detection
 from sfft.utils.WeightedQuantile import TopFlatten_Weighted_Quantile
@@ -134,8 +134,8 @@ class Hough_MorphClassifier:
         #
         """
 
-        skimage_version = parse_version(skimage.__version__)
-        assert parse_version('0.16.1') <= skimage_version <= parse_version('0.18.3')
+        skimage_version = version.parse(skimage.__version__)
+        assert version.parse('0.16.1') <= skimage_version <= version.parse('0.18.3')
         
         A_IMAGE = np.array(AstSEx['A_IMAGE'])
         B_IMAGE = np.array(AstSEx['B_IMAGE'])


### PR DESCRIPTION
Replaces the now deprecated pkg_resources.parse_version with packaging.version.parse. I didn't add a test to make sure it works against the different versions of skimage, but modern skimage is at 0.26.0 at this point, so I don't think this code will end up ever being used.